### PR TITLE
added customized opacity option and macos snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,44 @@
 > Hex-to-RGBA Allows designers to convert selected Hex Code to RGBA easily.
 
 ### Shortcuts
-  - ctrl-alt-h : converts selected text to RGBA
+#### converts selected text to RGBA
+  - Windows/Linux: ctrl-alt-h
+  - MacOS: cmd-shift-c
+
+*Pro Tip*: Postfix the opacity to the hex followed by `_` to add the opacity to the converted rgba.
+
+Example:
+`#333333_86` to generate `rgba(51, 51, 51, 0.86)`.
+
+
+----
 
 ![A screenshot of Hex-to-RGBA](https://media.giphy.com/media/xT9IgHS9RdgCmHAUfK/giphy.gif)
+
+![Using some pro-shortcuts](https://media.giphy.com/media/3ohhwnpVTGNhHtsK88/giphy.gif)
+
+### Tests
+
+```
+background: #ffb300;
+background: #ffb8f0_29;
+background: #000_52;
+background: #333333_19;
+background: #000000_6;
+background: #fff_96;
+background: #e3e3e3;
+background: #eee_08;
+background: #f3f3f3_81;
+
+\\ above tests simultaneously converted to:
+
+background: rgba(255, 179 ,0, 1);
+background: rgba(255, 184 ,240, 0.29);
+background: rgba(0, 0 ,82, 0.52);
+background: rgba(51, 51 ,51, 0.19);
+background: rgba(0, 0 ,0, 0.6);
+background: rgba(255, 15 ,150, 0.96);
+background: rgba(227, 227 ,227, 1);
+background: rgba(238, 14 ,8, 0.08);
+background: rgba(243, 243 ,243, 0.81);
+```

--- a/lib/hex-to-rgba.js
+++ b/lib/hex-to-rgba.js
@@ -48,8 +48,12 @@ export default {
   convert() {
     let editor
     if (editor = atom.workspace.getActiveTextEditor()) {
-      let selection = editor.getSelectedText()
-      selection = hexToRgba(selection, 100)
+      let selection = editor.getSelectedText();
+      let o = selection.split('_')[1] || 100;
+      o = o === "1" ? o = 100 :
+      		o < 10 && o.length == 1 ? o*10 :
+      		o;
+      selection = hexToRgba(selection, o)
       editor.insertText(selection)
     }
   }


### PR DESCRIPTION
* MacOS user can use `commmand+shift+c` to avail the snippet
* User can add opacity to the hex code using `_`(underscore) as the postfix.

Here is a snippet of the opacity functionality:
![Pro Snippets](https://media.giphy.com/media/3ohhwnpVTGNhHtsK88/giphy.gif)